### PR TITLE
Make sure the `certificate` key exists before setting it

### DIFF
--- a/src/Endpoints/Order.php
+++ b/src/Endpoints/Order.php
@@ -97,7 +97,11 @@ class Order extends Endpoint
         $response = $this->client->getHttpClient()->post($orderData->finalizeUrl, $signedPayload);
 
         if ($response->getHttpResponseCode() === 200) {
-            $orderData->setCertificateUrl($response->getBody()['certificate']);
+            $body = $response->getBody();
+
+            if (isset($body['certificate'])) {
+                $orderData->setCertificateUrl($body['certificate']);
+            }
 
             return true;
         }


### PR DESCRIPTION
When finalizing the order on the Let's Encrypt staging server, the response body does not include the `certificate` key, which causes an error. This change will only set the `certificate` key if it already exists.