### PR TITLE
Check all possible txt values

### DIFF
--- a/src/Support/LocalChallengeTest.php
+++ b/src/Support/LocalChallengeTest.php
@@ -33,10 +33,8 @@ class LocalChallengeTest
     {
         $response = @dns_get_record(sprintf('%s.%s', $name, $domain), DNS_TXT);
 
-        if (!empty($response[0]['txt']) && $response[0]['txt'] === $value) {
-            return;
+        if (!in_array($value, array_column($response, 'txt'), true)) {
+            throw DomainValidationException::localDnsChallengeTestFailed($domain);
         }
-
-        throw DomainValidationException::localDnsChallengeTestFailed($domain);
     }
 }


### PR DESCRIPTION
It is technically possible to have multiple TXT records for `_acme-challenge.your-domain.com`. However, currently only the first record is being checked. With this change, the given value will be checked against all possible TXT values for the specified domain.