### PR TITLE
give the possibility to override the server where the ACME Request is…

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -26,8 +26,14 @@ class Api
         private ?AcmeAccountInterface $localAccount = null,
         private ?LoggerInterface $logger = null,
         private HttpClientInterface|null $httpClient = null,
-    ) {
-        $this->baseUrl = $staging ? self::STAGING_URL : self::PRODUCTION_URL;
+        string $customUrl = ''
+    )
+    {
+        if ($staging) {
+            $this->baseUrl = empty($customUrl) ? (self::STAGING_URL) : $customUrl;
+        } else {
+            $this->baseUrl = empty($customUrl) ? (self::PRODUCTION_URL) : $customUrl;
+        }
     }
 
     public function setLocalAccount(AcmeAccountInterface $account): self

--- a/src/Api.php
+++ b/src/Api.php
@@ -27,8 +27,7 @@ class Api
         private ?LoggerInterface $logger = null,
         private HttpClientInterface|null $httpClient = null,
         string $customUrl = ''
-    )
-    {
+    ) {
         if ($staging) {
             $this->baseUrl = empty($customUrl) ? (self::STAGING_URL) : $customUrl;
         } else {


### PR DESCRIPTION
We need to use this with a local Server for internal certs. Just added this small snippet to work for us now and be able to not brick anything yet implemented