### PR TITLE
Use `Spatie/DNS` for local DNS validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "ext-mbstring": "*",
     "ext-openssl": "*",
     "psr/log": "^3.0",
+    "spatie/dns": "^2.5",
     "spatie/laravel-data": "^3.9"
   },
   "require-dev": {


### PR DESCRIPTION
This PR adds a dependency to [`spatie/dns`](https://github.com/spatie/dns) and uses it to validate the TXT DNS records in the LocalChallengeTest. 

Instead of using the system's default DNS resolver, it tries to fetch the actual nameserver used by the zone. If for some reason it cannot be found, then Google Public DNS is used. This approach will omit local caching issues