### PR TITLE
Use RuntimeException instead of Exception

### DIFF
--- a/src/Support/LocalChallengeTest.php
+++ b/src/Support/LocalChallengeTest.php
@@ -2,9 +2,9 @@
 
 namespace Rogierw\RwAcme\Support;
 
-use RuntimeException;
 use Rogierw\RwAcme\Exceptions\DomainValidationException;
 use Rogierw\RwAcme\Interfaces\HttpClientInterface;
+use RuntimeException;
 use Spatie\Dns\Dns;
 
 class LocalChallengeTest

--- a/src/Support/LocalChallengeTest.php
+++ b/src/Support/LocalChallengeTest.php
@@ -2,7 +2,7 @@
 
 namespace Rogierw\RwAcme\Support;
 
-use Exception;
+use RuntimeException;
 use Rogierw\RwAcme\Exceptions\DomainValidationException;
 use Rogierw\RwAcme\Interfaces\HttpClientInterface;
 use Spatie\Dns\Dns;

--- a/src/Support/LocalChallengeTest.php
+++ b/src/Support/LocalChallengeTest.php
@@ -52,7 +52,7 @@ class LocalChallengeTest
                     return;
                 }
             }
-        } catch (Exception) {
+        } catch (RuntimeException) {
             // An exception can be thrown by the Dns class when a lookup fails.
         }
 


### PR DESCRIPTION
Fixes: `spatie/dns` throws a [RuntimeException](https://github.com/spatie/dns/blob/main/src/Exceptions/CouldNotFetchDns.php#L8) instead of a normal exception