### PR TITLE
Improve local DNS challenge

### DIFF
--- a/src/Support/LocalChallengeTest.php
+++ b/src/Support/LocalChallengeTest.php
@@ -2,9 +2,9 @@
 
 namespace Rogierw\RwAcme\Support;
 
-use RuntimeException;
 use Rogierw\RwAcme\Exceptions\DomainValidationException;
 use Rogierw\RwAcme\Interfaces\HttpClientInterface;
+use RuntimeException;
 use Spatie\Dns\Dns;
 
 class LocalChallengeTest

--- a/src/Support/LocalChallengeTest.php
+++ b/src/Support/LocalChallengeTest.php
@@ -43,7 +43,7 @@ class LocalChallengeTest
                 return;
             }
 
-            // Try to validate a CNAME record pointing to a TXT recording containing the correct value
+            // Try to validate a CNAME record pointing to a TXT record containing the correct value.
             $cnameRecords = self::getRecords($nameserver, $challenge, DNS_CNAME);
             if (self::validateCnameRecords($cnameRecords, $value)) {
                 return;

--- a/src/Support/LocalChallengeTest.php
+++ b/src/Support/LocalChallengeTest.php
@@ -34,28 +34,76 @@ class LocalChallengeTest
     public static function dns(string $domain, string $name, string $value): void
     {
         try {
-            $dnsResolver = new Dns();
+            $challenge = sprintf('%s.%s', $name, $domain);
 
-            // Get the nameserver.
-            $soaRecord = $dnsResolver->getRecords($domain, DNS_SOA);
+            // Try to validate TXT records directly.
+            $nameserver = self::getNameserver($domain);
+            $txtRecords = self::getRecords($nameserver, $challenge, DNS_TXT);
+            if (self::validateTxtRecords($txtRecords, $value)) {
+                return;
+            }
 
-            $nameserver = empty($soaRecord)
-                ? self::DEFAULT_NAMESERVER
-                : $soaRecord[0]->mname();
-
-            $records = $dnsResolver
-                ->useNameserver($nameserver)
-                ->getRecords(sprintf('%s.%s', $name, $domain), DNS_TXT);
-
-            foreach ($records as $record) {
-                if ($record->txt() === $value) {
-                    return;
-                }
+            // Try to validate a CNAME record pointing to a TXT recording containing the correct value
+            $cnameRecords = self::getRecords($nameserver, $challenge, DNS_CNAME);
+            if (self::validateCnameRecords($cnameRecords, $value)) {
+                return;
             }
         } catch (RuntimeException) {
             // An exception can be thrown by the Dns class when a lookup fails.
         }
 
         throw DomainValidationException::localDnsChallengeTestFailed($domain);
+    }
+
+    private static function validateTxtRecords(array $records, string $value): bool
+    {
+        foreach ($records as $record) {
+            if ($record->txt() === $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function validateCnameRecords(array $records, string $value): bool
+    {
+        foreach ($records as $record) {
+            $nameserver = self::getNameserver($record->target());
+            $txtRecords = self::getRecords($nameserver, $record->target(), DNS_TXT);
+            if (self::validateTxtRecords($txtRecords, $value)) {
+                return true;
+            }
+
+            // If this is another CNAME, follow it.
+            $cnameRecords = self::getRecords($nameserver, $record->target(), DNS_CNAME);
+            if (!empty($cnameRecords)) {
+                if (self::validateCnameRecords($cnameRecords, $value)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static function getNameserver(string $domain): string
+    {
+        $dnsResolver = new Dns();
+
+        $result = $dnsResolver->getRecords($domain, DNS_NS);
+
+        return empty($result)
+            ? self::DEFAULT_NAMESERVER
+            : $result[0]->target();
+    }
+
+    private static function getRecords(string $nameserver, string $name, int $dnsType): array
+    {
+        $dnsResolver = new Dns();
+
+        return $dnsResolver
+            ->useNameserver($nameserver)
+            ->getRecords($name, $dnsType);
     }
 }


### PR DESCRIPTION
### What does it do?
1. It tries to validate TXT records directly, if found, return early.
2. If not found, try to validate CNAME records directly, follow that CNAME record and request the TXT record, repeat step 1.
3. If another CNAME was found, follow that and repeat step 2.

Furthermore instead of checking the SOA record for the nameserver of the domain/zone, it now uses the NS records. We found cases where the SOA record did not contain the nameserver in the mname field.

Closes #41 (again)