### PR TITLE
Remove legacy initialIP

### DIFF
--- a/src/DTO/AccountData.php
+++ b/src/DTO/AccountData.php
@@ -31,7 +31,7 @@ class AccountData extends Data
             status: $response->getBody()['status'],
             contact: $response->getBody()['contact'],
             agreement: $response->getBody()['agreement'] ?? '',
-            initialIp: $response->getBody()['initialIp'],
+            initialIp: $response->getBody()['initialIp'] ?? '',
             createdAt: $response->getBody()['createdAt']
         );
     }

--- a/src/DTO/AccountData.php
+++ b/src/DTO/AccountData.php
@@ -31,7 +31,6 @@ class AccountData extends Data
             status: $response->getBody()['status'],
             contact: $response->getBody()['contact'],
             agreement: $response->getBody()['agreement'] ?? '',
-            initialIp: $response->getBody()['initialIp'] ?? '',
             createdAt: $response->getBody()['createdAt']
         );
     }


### PR DESCRIPTION
We're receiving `Undefined array key "initialIp"`, apparently the initial IP isn't always returned, but we haven't found out yet why. This PR will prevent the undefined array key errors.