### PR TITLE
Fix empty JWS payload handling

### DIFF
--- a/src/Support/KeyId.php
+++ b/src/Support/KeyId.php
@@ -20,7 +20,7 @@ class KeyId
             'url' => $url,
         ];
 
-        $payload = is_array($payload)
+        $payload = is_array($payload) && count($payload) > 0
             ? str_replace('\\/', '/', json_encode($payload))
             : '';
 


### PR DESCRIPTION
Fixes #63

Empty payload arrays are now treated as an empty JWS payload instead of being JSON-encoded as [].